### PR TITLE
use image_url if available

### DIFF
--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -245,7 +245,11 @@ export class AvatarMetadata {
       await this._retrieveMetadata(spec);
     }
     if (!this.image) {
-      this.image = uri;
+      if (this.image_url) {
+        this.image = this.image_url;
+      } else {
+        this.image = uri;
+      }
     }
     await AvatarMetadata.parseURI(this.image as string);
     const { defaultProvider, ...rest } = this;
@@ -293,7 +297,7 @@ export class AvatarMetadata {
   static parseNFT(uri: string, seperator: string = '/') {
     assert(uri, 'parameter URI cannot be empty');
     // trim in case of whitespace on format
-    uri = uri.replace(/ /g, '').replace('did:nft:', ''); 
+    uri = uri.replace(/ /g, '').replace('did:nft:', '');
 
     const [reference, asset_namespace, token_id] = uri.split(seperator);
     const [_type, chain_id] = reference.split(':');


### PR DESCRIPTION
If no avatar image the uri was being used, causing the avatar src to be eip155... e.g. https://app.ens.domains/name/sheff.eth/details This fix uses the image_url if available