### PR TITLE
Assert resolver

### DIFF
--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -293,6 +293,7 @@ export class AvatarMetadata {
     try {
       // retrieve resolver by ens name
       var resolver = await this.defaultProvider.getResolver(uri);
+      assert(resolver, 'resolver is empty');
     } catch (e) {
       throw new ResolverNotFound(
         'There is no resolver set under given address'


### PR DESCRIPTION
resolver can return null which fails then errors with
'There is no avatar set under given address'

Rel: https://github.com/ensdomains/ens-metadata-service/issues/50