### PR TITLE
Fix ERC1155 ownership validation (#59)

### DIFF
--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -133,7 +133,7 @@ export class AvatarMetadata {
             owner && contract_1155.balanceOf(owner, token_id),
           ]);
           tokenURI = _tokenURI;
-          isOwner = !!owner && _isOwner.gt(0) === owner;
+          isOwner = !!owner && _isOwner.gt(0);
         } catch (error: any) {
           throw new RetrieveURIFailed(error.message);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number

<!--- If there is an associated github issues, please specify here -->
#59
## Description

<!--- Describe your changes in detail -->
Fix the ownership validation check if the token standard is ERC1155 so that the `is_owner` property of the response JSON object is set to `true` if ERC1155 NFT is owned by the ENS name's corresponding address. 

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Amend `isOwner` validation check in `_retrieveTokenURI` method if `namespace` is erc1155

## How Has This Been Tested?
Typed in the uri "https://metadata.ens.domains/[network]/avatar/[name]/meta" in browser with a few ENS names with an ERC1155 NFT record owned by the name and `is_owner` is set to `true` (e.g. https://metadata.ens.domains/mainnet/avatar/nick.eth/meta)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):
N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.