### PR TITLE
Fixing NFT image font issue where "i"s can get cut off

### DIFF
--- a/src/svg-template.ts
+++ b/src/svg-template.ts
@@ -95,6 +95,7 @@ export default function createSVGfromTemplate({
           font-weight:bold;
           font-style: normal;
           line-height: 34px;
+          letter-spacing: -0.0005em; /* Prevents dots in "i"s from being cut off with Jakarta font */
         }
       </style>
       <linearGradient id="paint0_linear" x1="190.5" y1="302" x2="-64" y2="-172.5" gradientUnits="userSpaceOnUse">


### PR DESCRIPTION
Resolves #61.

This tweaks the letter-spacing style of the text used for the NFT overlay, as little as possible while still working in all browsers. For example in Brave/Chrome/Opera/Edge, using -0.00001em was enough. However in Firefox I had to go to -0.0003em for the "i" to no longer be cut off.

When "fi" appears in the text anywhere, this will cause the browser to render the "i" properly with the dot. In most other cases this will have no visible difference for users, at most a few letters will be shifted by 1px.

Browsers tested:
Brave 1.32.113 (Chromium: 96.0.4664.45)
Chrome 96.0.4664.93
Firefox 95.0
Opera 82.0.4227.23
Edge 96.0.1054.53