### PR TITLE
change ens-validation library with unicode-confusables

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Makoto Inoue <2630+makoto@users.noreply.github.com>",
   "license": "MIT",
   "dependencies": {
-    "@ensdomains/ens-validation": "^0.1.0",
     "@ensdomains/eth-ens-namehash": "^2.0.15",
+    "@ensdomains/unicode-confusables": "^0.1.0",
     "@types/lodash": "^4.14.170",
     "btoa": "^1.2.1",
     "canvas": "^2.8.0",

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -10,7 +10,7 @@ import createSVGfromTemplate from './svg-template';
 const btoa                           = require('btoa');
 const { createCanvas, registerFont } = require('canvas');
 const namehash                       = require('@ensdomains/eth-ens-namehash');
-const { validate }                   = require('@ensdomains/ens-validation');
+const { isConfusing }                = require('@ensdomains/unicode-confusables');
 
 registerFont(
   CANVAS_FONT_PATH, 
@@ -65,7 +65,7 @@ export class Metadata {
     tokenId,
     version,
   }: MetadataInit) {
-    const is_valid = validate(name);
+    const is_valid = !isConfusing(name);
     this.is_normalized = is_valid && this._checkNormalized(name);
     this.name = this.is_normalized
       ? name

--- a/src/svg-template.ts
+++ b/src/svg-template.ts
@@ -16,7 +16,7 @@ interface SVGTemplateFields {
   backgroundImage?: string;
   domain: string;
   domainFontSize: number;
-  isNormalized: boolean;
+  isValid: boolean;
   isSubdomain: boolean;
   mimeType?: string;
   subdomainText?: string;
@@ -27,7 +27,7 @@ export default function createSVGfromTemplate({
   backgroundImage,
   domain,
   domainFontSize,
-  isNormalized = true,
+  isValid = true,
   isSubdomain = false,
   mimeType,
   subdomainText,
@@ -43,7 +43,7 @@ export default function createSVGfromTemplate({
         </defs>
         <rect width="270" height="270" fill="url(#backImg)"/>
         <rect width="270" height="270" fill="#000" fill-opacity=".12"/>`
-        : isNormalized
+        : isValid
           ? `<rect width="270" height="270" fill="url(#paint0_linear)"/>`
           : `<rect width="270" height="270" fill="url(#paint1_linear)"/>`
     }
@@ -57,7 +57,7 @@ export default function createSVGfromTemplate({
     <path d="M70.1927 60.9125C69.6928 59.9159 68.4555 57.946 68.4555 57.946L54.1514 80L68.1118 70.9138C68.9436 70.3962 69.6261 69.6956 70.099 68.8739C70.7358 67.6334 71.0741 66.2781 71.0903 64.9029C71.1065 63.5277 70.8001 62.1657 70.1927 60.9125Z" fill="white" filter="url(#dropShadow)"/>
     <path d="M74.8512 52.8328C74.7008 50.7229 74.0909 48.6688 73.0624 46.8081C72.0339 44.9473 70.6105 43.3228 68.8876 42.0433L54.1514 32C54.1514 32 63.3652 44.987 71.1478 57.9098C71.933 59.2755 72.4603 60.7682 72.7043 62.3165C72.8132 63.0178 72.8132 63.7311 72.7043 64.4324C72.9071 64.0652 73.3007 63.3133 73.3007 63.3133C74.0892 61.7414 74.6262 60.0606 74.893 58.3295C75.0485 56.4998 75.0345 54.66 74.8512 52.8328Z" fill="white" filter="url(#dropShadow)"/>
     ${
-      isNormalized
+      isValid
         ? ''
         : `
       <rect x="200" y="34" width="40" height="40" rx="20" fill="white" fill-opacity="0.2"/>

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,15 +208,17 @@
   dependencies:
     arrify "^1.0.1"
 
-"@ensdomains/ens-validation@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@ensdomains/ens-validation/-/ens-validation-0.1.0.tgz#9ebfe66016fbf069a6ebca70c043714f6f02fbe6"
-  integrity sha512-rbDh2K6GfqXvBcJUISaTTYEt3f079WA4ohTE5Lh4/8EaaPAk/9vk3EisMUQV2UVxeFIZQEEyRCIOmRTpqN0W7A==
-
 "@ensdomains/eth-ens-namehash@^2.0.15":
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/@ensdomains/eth-ens-namehash/-/eth-ens-namehash-2.0.15.tgz#5e5f2f24ba802aff8bc19edd822c9a11200cdf4a"
   integrity sha512-JRDFP6+Hczb1E0/HhIg0PONgBYasfGfDheujmfxaZaAv/NAH4jE6Kf48WbqfRZdxt4IZI3jl3Ri7sZ1nP09lgw==
+
+"@ensdomains/unicode-confusables@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@ensdomains/unicode-confusables/-/unicode-confusables-0.1.0.tgz#0aaa4cf1ac40bbb087f1ede899d8b86a021f26fb"
+  integrity sha512-U9I7pIHWMeiBNPyQlyvSTGKLzXZ7UQF8SQUEKIQPuW0L3E1JBap56I6D+DT9UpOYdGYdt576oCLfhTM92gSo/Q==
+  dependencies:
+    emoji-regex "^10.0.1"
 
 "@ethereumjs/common@^2.3.0", "@ethereumjs/common@^2.4.0":
   version "2.4.0"
@@ -2492,6 +2494,11 @@ emittery@^0.8.0:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
   integrity sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==
+
+emoji-regex@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.0.1.tgz#77180edb279b99510a21b79b19e1dc283d8f3991"
+  integrity sha512-cLuZzriSWVE+rllzeq4zpUEoCPfYEbQ6ZVhIq+ed6ynWST7Bw9XnOr+bKWgCup4paq72DI21gw9M3aaFkm4HAw==
 
 emoji-regex@^7.0.1:
   version "7.0.3"


### PR DESCRIPTION
Resolves #79 #71 

[Unicode confusables table](https://unicode.org/Public/security/latest/confusables.txt) is not good source to verify the names as it is. It has some controversial rules which may affect ENS owners negatively. Such as;
```txt
006D ;	0072 006E ;	MA	# ( m → rn ) LATIN SMALL LETTER M → LATIN SMALL LETTER R, LATIN SMALL LETTER N	# 
```

So I will keep this PR as draft until we have a proper and safe implementation.