### PR TITLE
endpoint updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "main": "index.js",
   "author": "Makoto Inoue <2630+makoto@users.noreply.github.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@ensdomains/ens-avatar": "^0.1.1",
     "@ensdomains/ens-validation": "^0.1.0",

--- a/src/controller/ensImage.ts
+++ b/src/controller/ensImage.ts
@@ -4,6 +4,7 @@ import { ContractMismatchError, UnsupportedNetwork } from '../base';
 import { checkContract } from '../service/contract';
 import { getDomain } from '../service/domain';
 import getNetwork from '../service/network';
+import { getLabelhash } from '../utils/labelhash';
 
 /* istanbul ignore next */
 export async function ensImage (req: Request, res: Response) {
@@ -12,15 +13,25 @@ export async function ensImage (req: Request, res: Response) {
   // #swagger.parameters['contractAddress'] = { description: 'Contract address which stores the NFT indicated by the tokenId' }
   // #swagger.parameters['tokenId'] = { description: 'Namehash(v1) /Labelhash(v2) of your ENS name.\n\nMore: https://docs.ens.domains/contract-api-reference/name-processing#hashing-names' }
   const { contractAddress, networkName, tokenId } = req.params;
+
+  // check if token id provided as raw ens name, if so then convert to labelhash
+  // TODO add namehash conversion for v2
+  let _tokenId;
+  if (tokenId.endsWith('.eth')) {
+    _tokenId = getLabelhash(tokenId)
+  } else {
+    _tokenId = tokenId
+  }
+
   try {
     const { provider, SUBGRAPH_URL } = getNetwork(networkName);
-    const version = await checkContract(provider, contractAddress, tokenId);
+    const version = await checkContract(provider, contractAddress, _tokenId);
     const result = await getDomain(
       provider,
       networkName,
       SUBGRAPH_URL,
       contractAddress,
-      tokenId,
+      _tokenId,
       version
     );
     if (result.image_url) {

--- a/src/controller/ensMetadata.ts
+++ b/src/controller/ensMetadata.ts
@@ -4,48 +4,56 @@ import { ContractMismatchError } from '../base';
 import { checkContract } from '../service/contract';
 import { getDomain } from '../service/domain';
 import getNetwork from '../service/network';
+import { getLabelhash } from '../utils/labelhash';
 
-export async function ensMetadata (req: Request, res: Response) {
-    // #swagger.description = 'ENS NFT metadata'
-    // #swagger.parameters['networkName'] = { description: 'Name of the chain to query for. (mainnet|rinkeby|ropsten|goerli...)' }
-    // #swagger.parameters['{}'] = { name: 'contractAddress', description: 'Contract address which stores the NFT indicated by the tokenId' }
-    // #swagger.parameters['tokenId'] = { description: 'Namehash(v1) /Labelhash(v2) of your ENS name.\n\nMore: https://docs.ens.domains/contract-api-reference/name-processing#hashing-names' }
-    const { contractAddress, networkName, tokenId } = req.params;
-    try {
-      const { provider, SUBGRAPH_URL } = getNetwork(networkName);
-      const version = await checkContract(provider, contractAddress, tokenId);
-      const result = await getDomain(
-        provider,
-        networkName,
-        SUBGRAPH_URL,
-        contractAddress,
-        tokenId,
-        version,
-        false
-      );
-      /* #swagger.responses[200] = { 
+export async function ensMetadata(req: Request, res: Response) {
+  // #swagger.description = 'ENS NFT metadata'
+  // #swagger.parameters['networkName'] = { description: 'Name of the chain to query for. (mainnet|rinkeby|ropsten|goerli...)' }
+  // #swagger.parameters['{}'] = { name: 'contractAddress', description: 'Contract address which stores the NFT indicated by the tokenId' }
+  // #swagger.parameters['tokenId'] = { description: 'Namehash(v1) /Labelhash(v2) of your ENS name.\n\nMore: https://docs.ens.domains/contract-api-reference/name-processing#hashing-names' }
+  const { contractAddress, networkName, tokenId } = req.params;
+
+  // check if token id provided as raw ens name, if so then convert to labelhash
+  // TODO add namehash conversion for v2
+  let _tokenId;
+  if (tokenId.endsWith('.eth')) {
+    _tokenId = getLabelhash(tokenId);
+  } else {
+    _tokenId = tokenId;
+  }
+
+  try {
+    const { provider, SUBGRAPH_URL } = getNetwork(networkName);
+    const version = await checkContract(provider, contractAddress, _tokenId);
+    const result = await getDomain(
+      provider,
+      networkName,
+      SUBGRAPH_URL,
+      contractAddress,
+      _tokenId,
+      version,
+      false
+    );
+    /* #swagger.responses[200] = { 
              description: 'Metadata object' 
       } */
-      res.json(result);
-    } catch (error: any) {
-      console.log('error', error);
-      let errCode = (error?.code && Number(error.code)) || 500;
-      if (
-        error instanceof FetchError ||
-        error instanceof ContractMismatchError
-      ) {
-        if (errCode !== 404) {
-          res.status(errCode).json({
-            message: error.message,
-          });
-          return;
-        }
+    res.json(result);
+  } catch (error: any) {
+    console.log('error', error);
+    let errCode = (error?.code && Number(error.code)) || 500;
+    if (error instanceof FetchError || error instanceof ContractMismatchError) {
+      if (errCode !== 404) {
+        res.status(errCode).json({
+          message: error.message,
+        });
+        return;
       }
-      /* #swagger.responses[404] = { 
+    }
+    /* #swagger.responses[404] = { 
              description: 'No results found.' 
       } */
-      res.status(404).json({
-        message: 'No results found.',
-      });
-    }
+    res.status(404).json({
+      message: 'No results found.',
+    });
   }
+}

--- a/src/controller/queryNFT.ts
+++ b/src/controller/queryNFT.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from 'express';
+import { queryNFT } from '../service/queryNFT';
+
+/* istanbul ignore next */
+export async function queryNFTep(req: Request, res: Response) {
+  // #swagger.description = 'Query endpoint for NFT URIs'
+  // #swagger.parameters['uri'] = { in: 'query', description: 'NFT URI as defined under CAIP-22 for erc721 assets and CAIP-29 for erc1155 assets.' }
+  const { uri } = req.query;
+  if (!uri) {
+    throw Error(
+      'Please be sure adding your NFT URI as a query. i.e. /queryNFT?uri=eip155:1/erc721:0x...'
+    );
+  }
+  try {
+    const metadata = await queryNFT(uri as string);
+    res.status(200).json(metadata);
+  } catch (error) {
+    res.status(500).json({
+      message: error,
+    });
+  }
+}

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -5,6 +5,7 @@ import { ensImage } from './controller/ensImage';
 import { ensRasterize } from './controller/ensRasterize';
 import { avatarMetadata } from './controller/avatarMetadata';
 import { avatarImage } from './controller/avatarImage';
+import { queryNFTep } from './controller/queryNFT';
 
 export default function (app: Express) {
   app.get('/', (_req, res) => {
@@ -29,4 +30,6 @@ export default function (app: Express) {
   app.get('/:networkName/avatar/:name/meta', avatarMetadata);
 
   app.get('/:networkName/avatar/:name', avatarImage);
+
+  app.get('/queryNFT', queryNFTep);
 }

--- a/src/service/queryNFT.ts
+++ b/src/service/queryNFT.ts
@@ -1,0 +1,42 @@
+import { utils, specs, UnsupportedNamespace } from '@ensdomains/ens-avatar';
+import getNetwork from '../service/network';
+import { UnsupportedNetwork } from '../base';
+
+const networks: { [key: string]: string } = {
+  '1': 'mainnet',
+  '3': 'ropsten',
+  '4': 'rinkeby',
+  '5': 'goerli',
+};
+
+export async function queryNFT(uri: string) {
+  const { chainID, namespace, contractAddress, tokenID } = utils.parseNFT(
+    uri as string
+  );
+  const Spec = specs[namespace];
+  if (!Spec)
+    throw new UnsupportedNamespace(`Unsupported namespace: ${namespace}`);
+  const spec = new Spec();
+  // add meta information of the avatar record
+  const host_meta = {
+    chain_id: chainID,
+    namespace,
+    contract_address: contractAddress,
+    token_id: tokenID,
+    reference_url: `https://opensea.io/assets/${contractAddress}/${tokenID}`,
+  };
+  const networkName = networks[chainID.toString()];
+  if (!networkName)
+    throw new UnsupportedNetwork(
+      `chainID ${chainID.toString()} is unsupported`
+    );
+  const { provider } = getNetwork(networkName);
+  // retrieve metadata, omit "is_owner" field
+  const { is_owner, ...metadata } = await spec.getMetadata(
+    provider,
+    undefined,
+    contractAddress,
+    tokenID
+  );
+  return { host_meta, ...metadata };
+}

--- a/src/utils/labelhash.ts
+++ b/src/utils/labelhash.ts
@@ -1,0 +1,11 @@
+import { ethers, utils } from 'ethers';
+export const labelhash = (label: string) =>
+  utils.keccak256(utils.toUtf8Bytes(label));
+
+export function getLabelhash(name: string) {
+  // remove tld before conversion
+  if (name.endsWith('.eth')) name = name.slice(0, -4);
+  const lhexId = labelhash(name);
+  const lintId = ethers.BigNumber.from(lhexId).toString();
+  return lintId;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,7 +2069,7 @@ ci-parallel-vars@^1.0.1:
   resolved "https://registry.yarnpkg.com/ci-parallel-vars/-/ci-parallel-vars-1.0.1.tgz#e87ff0625ccf9d286985b29b4ada8485ca9ffbc2"
   integrity sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==
 
-"cid@github:multiformats/cid":
+cid@multiformats/cid:
   version "0.0.0"
   resolved "https://codeload.github.com/multiformats/cid/tar.gz/97ff4a329f04b70c1ab7255c62af48192146b025"
 


### PR DESCRIPTION
- add queryNFT endpoint for preview purposes. Resolves #84.
e.g. `/queryNFT?uri=eip155:1/erc721:0xb7F7F6C52F2e2fdb1963Eab30438024864c313F6/2430`
- allow raw ens name to be used as tokenID on ENS NFT metadata and image endpoints. Resolves  #85.