### PR TITLE
unknown name template

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,17 +15,24 @@ const INFURA_API_KEY = process.env.INFURA_API_KEY;
 const IPFS_GATEWAY = 'https://ipfs.io/';
 
 const ADDRESS_ETH_REGISTRAR = process.env.ADDRESS_ETH_REGISTRAR || '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85';
+const ADDRESS_ETH_REGISTRY = process.env.ADDRESS_ETH_REGISTRY || '0x00000000000c2e074ec69a0dfb2997ba6c7d2e1e'
 const ADDRESS_NAME_WRAPPER = process.env.ADDRESS_NAME_WRAPPER || '0x4D83cea620E3864F912046b73bB3a6c04Da75990';
 
 const SERVER_URL =
   ENV === 'local' ? `http://localhost:${PORT}` : `https://${HOST}`;
 
+const ETH_REGISTRY_ABI = [
+  'function recordExists(bytes32 node) external view returns (bool)'
+];
+
 export {
   ADDRESS_ETH_REGISTRAR,
+  ADDRESS_ETH_REGISTRY,
   ADDRESS_NAME_WRAPPER,
   CANVAS_FONT_PATH,
   CANVAS_EMOJI_FONT_PATH,
   CANVAS_FALLBACK_FONT_PATH,
+  ETH_REGISTRY_ABI,
   INAMEWRAPPER,
   INFURA_API_KEY,
   IPFS_GATEWAY,

--- a/src/controller/ensMetadata.ts
+++ b/src/controller/ensMetadata.ts
@@ -66,7 +66,7 @@ export async function ensMetadata(req: Request, res: Response) {
         ETH_REGISTRY_ABI,
         provider
       );
-      const _namehash = constructEthNameHash(tokenId);
+      const _namehash = constructEthNameHash(_tokenId);
       const isRecordExist = await registry.recordExists(_namehash);
       assert(isRecordExist, 'ENS name does not exist');
     } catch (error) {

--- a/src/controller/ensMetadata.ts
+++ b/src/controller/ensMetadata.ts
@@ -1,51 +1,54 @@
 import { Request, Response } from 'express';
 import { FetchError } from 'node-fetch';
-import { ContractMismatchError } from '../base';
+import { ContractMismatchError, Version } from '../base';
 import { checkContract } from '../service/contract';
 import { getDomain } from '../service/domain';
+import { Metadata } from '../service/metadata';
 import getNetwork from '../service/network';
 
-export async function ensMetadata (req: Request, res: Response) {
-    // #swagger.description = 'ENS NFT metadata'
-    // #swagger.parameters['networkName'] = { description: 'Name of the chain to query for. (mainnet|rinkeby|ropsten|goerli...)' }
-    // #swagger.parameters['{}'] = { name: 'contractAddress', description: 'Contract address which stores the NFT indicated by the tokenId' }
-    // #swagger.parameters['tokenId'] = { description: 'Namehash(v1) /Labelhash(v2) of your ENS name.\n\nMore: https://docs.ens.domains/contract-api-reference/name-processing#hashing-names' }
-    const { contractAddress, networkName, tokenId } = req.params;
-    try {
-      const { provider, SUBGRAPH_URL } = getNetwork(networkName);
-      const version = await checkContract(provider, contractAddress, tokenId);
-      const result = await getDomain(
-        provider,
-        networkName,
-        SUBGRAPH_URL,
-        contractAddress,
-        tokenId,
-        version,
-        false
-      );
-      /* #swagger.responses[200] = { 
+export async function ensMetadata(req: Request, res: Response) {
+  // #swagger.description = 'ENS NFT metadata'
+  // #swagger.parameters['networkName'] = { description: 'Name of the chain to query for. (mainnet|rinkeby|ropsten|goerli...)' }
+  // #swagger.parameters['{}'] = { name: 'contractAddress', description: 'Contract address which stores the NFT indicated by the tokenId' }
+  // #swagger.parameters['tokenId'] = { description: 'Namehash(v1) /Labelhash(v2) of your ENS name.\n\nMore: https://docs.ens.domains/contract-api-reference/name-processing#hashing-names' }
+  const { contractAddress, networkName, tokenId } = req.params;
+  try {
+    const { provider, SUBGRAPH_URL } = getNetwork(networkName);
+    const version = await checkContract(provider, contractAddress, tokenId);
+    const result = await getDomain(
+      provider,
+      networkName,
+      SUBGRAPH_URL,
+      contractAddress,
+      tokenId,
+      version,
+      false
+    );
+    /* #swagger.responses[200] = { 
              description: 'Metadata object' 
       } */
-      res.json(result);
-    } catch (error: any) {
-      console.log('error', error);
-      let errCode = (error?.code && Number(error.code)) || 500;
-      if (
-        error instanceof FetchError ||
-        error instanceof ContractMismatchError
-      ) {
-        if (errCode !== 404) {
-          res.status(errCode).json({
-            message: error.message,
-          });
-          return;
-        }
+    res.json(result);
+  } catch (error: any) {
+    console.log('error', error);
+    let errCode = (error?.code && Number(error.code)) || 500;
+    if (error instanceof FetchError || error instanceof ContractMismatchError) {
+      if (errCode !== 404) {
+        res.status(errCode).json({
+          message: error.message,
+        });
+        return;
       }
-      /* #swagger.responses[404] = { 
-             description: 'No results found.' 
-      } */
-      res.status(404).json({
-        message: 'No results found.',
-      });
     }
+    // When entry is not available, return unknown name metadata with 200 status code
+    const { url, ...unknownMetadata } = new Metadata({
+      name: 'unknown.name',
+      description: 'Unknown ENS name',
+      created_date: 1580346653000,
+      tokenId: '',
+      version: Version.v1,
+    });
+    res.status(200).json({
+      message: unknownMetadata,
+    });
   }
+}

--- a/src/utils/namehash.ts
+++ b/src/utils/namehash.ts
@@ -1,0 +1,20 @@
+import { utils, BigNumber } from 'ethers';
+var sha3 = require('js-sha3').keccak_256;
+
+const eth0x =
+  '4f5b812789fc606be1b3b16908db13fc7a9adf7ca72641f84d75b47069d3d7f0';
+
+export function constructEthNameHash(tokenId: string): string {
+  const label0x = utils
+    .hexZeroPad(utils.hexlify(BigNumber.from(tokenId)), 32)
+    .replace('0x', '');
+  const labels = [label0x, eth0x];
+
+  // 0 x 64
+  let node = '0000000000000000000000000000000000000000000000000000000000000000';
+  for (var i = labels.length - 1; i >= 0; i--) {
+    var labelSha = labels[i];
+    node = sha3(Buffer.from(node + labelSha, 'hex'));
+  }
+  return '0x' + node;
+}

--- a/test/entry.mock.ts
+++ b/test/entry.mock.ts
@@ -38,7 +38,14 @@ export class MockEntry {
     this.namehash = namehash.hash(name);
 
     if (unknown) {
-      this.expect = 'No results found.';
+      const { url, ...unknownMetadata } = new Metadata({
+        name: 'unknown.name',
+        description: 'Unknown ENS name',
+        created_date: 1580346653000,
+        tokenId: '',
+        version: Version.v1,
+      });
+      this.expect = JSON.parse(JSON.stringify(unknownMetadata));
       nock(SUBGRAPH_URL.origin)
         .post(SUBGRAPH_URL.pathname, {
           query: GET_DOMAINS,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -50,7 +50,7 @@ const sub2Wrappertest9 = new MockEntry({
   resolver: { texts: ['domains.ens.nft.image'] },
   hasImageKey: true,
 });
-const unknown = new MockEntry({ name: 'unknown.eth', unknown: true });
+const unknown = new MockEntry({ name: 'unknown.name', unknown: true });
 const handle21character = new MockEntry({
   name: 'handle21character.eth',
   registration: true,
@@ -230,15 +230,11 @@ test('get /:contractAddress/:tokenId for a greater than MAX_CHAR long subdomain'
 });
 
 test('get /:contractAddress/:tokenId for unknown namehash', async (t: ExecutionContext<TestContext>) => {
-  const {
-    response: { statusCode, body },
-  }: HTTPError = await t.throwsAsync(
-    () => got(`rinkeby/${NAME_WRAPPER_ADDRESS}/${unknown.namehash}`, options),
-    { instanceOf: HTTPError }
-  );
-  const message = JSON.parse(body as string)?.message;
-  t.is(message, unknown.expect);
-  t.is(statusCode, 404);
+  const { message } = await got(
+    `rinkeby/${NAME_WRAPPER_ADDRESS}/${unknown.namehash}`,
+    options
+  ).json();
+  t.deepEqual(message, unknown.expect);
 });
 
 test('get /:contractAddress/:tokenId for empty tokenId', async (t: ExecutionContext<TestContext>) => {
@@ -270,23 +266,16 @@ test('raise 404 status from subgraph connection', async (t: ExecutionContext<Tes
       },
     })
     .replyWithError(fetchError);
-  const {
-    response: { body, statusCode },
-  }: HTTPError = await t.throwsAsync(
-    () =>
-      got(`rinkeby/${NAME_WRAPPER_ADDRESS}/${sub1Wrappertest.namehash}`, {
-        ...options,
-        retry: 0,
-      }),
+  const { message } = await got(
+    `rinkeby/${NAME_WRAPPER_ADDRESS}/${sub1Wrappertest.namehash}`,
     {
-      instanceOf: HTTPError,
+      ...options,
+      retry: 0,
     }
-  );
-  const { message } = JSON.parse(body as string);
+  ).json();
   // Regardless of what is the message in subgraph with status 404 code
-  // user will always see "No results found."" instead
-  t.assert(message.includes('No results found.'));
-  t.is(statusCode, fetchError.statusCode);
+  // user will always see "Unknown name"" template instead
+  t.deepEqual(message, unknown.expect);
 });
 
 test('raise ECONNREFUSED from subgraph connection', async (t: ExecutionContext<TestContext>) => {
@@ -303,21 +292,14 @@ test('raise ECONNREFUSED from subgraph connection', async (t: ExecutionContext<T
       },
     })
     .replyWithError(fetchError);
-  const {
-    response: { body, statusCode },
-  }: HTTPError = await t.throwsAsync(
-    () =>
-      got(`rinkeby/${NAME_WRAPPER_ADDRESS}/${sub1Wrappertest.namehash}`, {
-        ...options,
-        retry: 0,
-      }),
+  const { message } = await got(
+    `rinkeby/${NAME_WRAPPER_ADDRESS}/${sub1Wrappertest.namehash}`,
     {
-      instanceOf: HTTPError,
+      ...options,
+      retry: 0,
     }
-  );
-  const { message } = JSON.parse(body as string);
-  t.assert(message.includes('No results found.'));
-  t.is(statusCode, 404);
+  ).json();
+  t.deepEqual(message, unknown.expect);
 });
 
 test('raise Internal Server Error from subgraph', async (t: ExecutionContext<TestContext>) => {
@@ -334,21 +316,14 @@ test('raise Internal Server Error from subgraph', async (t: ExecutionContext<Tes
       },
     })
     .replyWithError(fetchError);
-  const {
-    response: { body, statusCode },
-  }: HTTPError = await t.throwsAsync(
-    () =>
-      got(`rinkeby/${NAME_WRAPPER_ADDRESS}/${sub1Wrappertest.namehash}`, {
-        ...options,
-        retry: 0,
-      }),
+  const { message } = await got(
+    `rinkeby/${NAME_WRAPPER_ADDRESS}/${sub1Wrappertest.namehash}`,
     {
-      instanceOf: HTTPError,
+      ...options,
+      retry: 0,
     }
-  );
-  const { message } = JSON.parse(body as string);
-  t.assert(message.includes('No results found.'));
-  t.is(statusCode, 404);
+  ).json();
+  t.deepEqual(message, unknown.expect);
 });
 
 test('raise timeout from subgraph', async (t: ExecutionContext<TestContext>) => {
@@ -362,19 +337,14 @@ test('raise timeout from subgraph', async (t: ExecutionContext<TestContext>) => 
     .delayConnection(2000) // 2 seconds
     .replyWithError({ code: 'ETIMEDOUT' })
     .persist(false);
-  const {
-    response: { statusCode },
-  }: HTTPError = await t.throwsAsync(
-    () =>
-      got(`rinkeby/${NAME_WRAPPER_ADDRESS}/${sub1Wrappertest.namehash}`, {
-        ...options,
-        retry: 0,
-      }),
+  const { message } = await got(
+    `rinkeby/${NAME_WRAPPER_ADDRESS}/${sub1Wrappertest.namehash}`,
     {
-      instanceOf: HTTPError,
+      ...options,
+      retry: 0,
     }
-  );
-  t.assert(statusCode === 404);
+  ).json();
+  t.deepEqual(message, unknown.expect);
 });
 
 test('raise ContractMismatchError', async (t: ExecutionContext<TestContext>) => {


### PR DESCRIPTION
Due to sub-graph delay, metadata service fails to retrieve freshly registered names and returns 404 instead. To solve this problem, before returning 404 we check if registry has any record for given name.

First iteration of the implementation were checking ENS Registry if given record is exist by calling "recordExist" method,
but then I realized we already do a call to the registrar to determine if given name has an owner, so now we use `OwnerNotFound` error to determine if there is already owned name or not.