### PR TITLE
add codepoint and segment length

### DIFF
--- a/src/service/metadata.ts
+++ b/src/service/metadata.ts
@@ -7,7 +7,7 @@ import {
 import createSVGfromTemplate from '../svg-template';
 import base64EncodeUnicode   from '../utils/base64encode';
 import { findCharacterSet }  from '../utils/characterSet';
-import { getCharCodeLength, getSegmentLength }  from '../utils/charLength';
+import { getCodePointLength, getSegmentLength }  from '../utils/charLength';
 
 // no ts decleration files
 
@@ -231,7 +231,7 @@ https://en.wikipedia.org/wiki/IDN_homograph_attack';
   private _labelCharLength(name: string): number {
     const label = name.substring(0, name.indexOf('.'));
     if (!label) throw Error('Label cannot be empty!');
-    return getCharCodeLength(label);
+    return getCodePointLength(label);
   }
 
   private _labelSegmentLength(name: string): number {

--- a/src/utils/charLength.ts
+++ b/src/utils/charLength.ts
@@ -10,5 +10,5 @@ export function getSegmentLength(name: string): number {
 
 export function getCodePointLength(name: string): number {
   // spread operator will split string into its codepoints
-  return [...name].length
+  return [...name].length;
 }

--- a/src/utils/charLength.ts
+++ b/src/utils/charLength.ts
@@ -8,7 +8,7 @@ export function getSegmentLength(name: string): number {
   return [...new Intl.Segmenter().segment(name)].length;
 }
 
-export function getCharCodeLength(name: string): number {
+export function getCodePointLength(name: string): number {
   // spread operator will split string into its codepoints
   return [...name].length
 }

--- a/src/utils/charLength.ts
+++ b/src/utils/charLength.ts
@@ -4,6 +4,11 @@ declare namespace Intl {
   }
 }
 
-export default function getCharLength(name: string): number {
+export function getSegmentLength(name: string): number {
   return [...new Intl.Segmenter().segment(name)].length;
+}
+
+export function getCharCodeLength(name: string): number {
+  // spread operator will split string into its codepoints
+  return [...name].length
 }


### PR DESCRIPTION
currently character length of ens names calculated based on their segment amount. however this results with misunderstanding in marketplaces for the ens names which occurs from emoji character set.

e.g.
in current setup `🇳🇿🇳🇿🇳🇿.eth` name occurs from 3 segments, but from the registry point of view this name has 6 character in it. the codepoints of the name is as given;  `[ '🇳', '🇿', '🇳', '🇿', '🇳', '🇿' ]`.

This PR aims to remove aforementioned ambiguity by having code point length as default length and providing segment length of the name as an additional information.