### PR TITLE
re-enable created date for v1

### DIFF
--- a/src/service/subgraph.ts
+++ b/src/service/subgraph.ts
@@ -30,6 +30,7 @@ export const GET_DOMAINS_BY_LABELHASH = gql`
       id
       labelhash
       name
+      createdAt
       parent {
         id
       }


### PR DESCRIPTION
Resolves #101 

in the current namewrapper contract `createdAt` parameter returns `undefined`, due to that issue we were not showing `createdAt` parameter in both NFT versions for consistency, but in fact name wrapper contract is not in production yet, and there is a demand for this information, re-enabling it will be beneficial.

Relevant issue #29

Discuss: https://discuss.ens.domains/t/include-the-original-first-registration-date-and-time-in-the-ens-metadata/12414