### PR TITLE
add error message for expired names

### DIFF
--- a/mock/entry.mock.ts
+++ b/mock/entry.mock.ts
@@ -113,21 +113,21 @@ export class MockEntry {
       this.registrationResponse = {
         registrations: [
           {
-            expiryDate: randomDate,
+            expiryDate: (+new Date() + 31536000000).toString(),
             labelName: name,
-            registrationDate: randomDate,
+            registrationDate: (+new Date() - 157680000000).toString(),
           },
         ],
       };
       _metadata.addAttribute({
         trait_type: 'Registration Date',
         display_type: 'date',
-        value: +randomDate * 1000,
+        value: (+new Date() - 157680000000) * 1000,
       });
       _metadata.addAttribute({
         trait_type: 'Expiration Date',
         display_type: 'date',
-        value: +randomDate * 1000,
+        value: (+new Date() + 31536000000) * 1000,
       });
 
       nock(SUBGRAPH_URL.origin)

--- a/mock/entry.mock.ts
+++ b/mock/entry.mock.ts
@@ -77,6 +77,8 @@ export class MockEntry {
     }
 
     const randomDate = this.getRandomDate();
+    const registrationDate = +new Date() - 157680000000;
+    const expiryDate = +new Date() + 31536000000;
     const labelName = name.split('.')[0];
     const labelhash = utils.keccak256(utils.toUtf8Bytes(labelName));
     const _metadata = new Metadata({
@@ -113,21 +115,21 @@ export class MockEntry {
       this.registrationResponse = {
         registrations: [
           {
-            expiryDate: (+new Date() + 31536000000).toString(),
+            expiryDate: expiryDate.toString(),
             labelName: name,
-            registrationDate: (+new Date() - 157680000000).toString(),
+            registrationDate: registrationDate.toString(),
           },
         ],
       };
       _metadata.addAttribute({
         trait_type: 'Registration Date',
         display_type: 'date',
-        value: (+new Date() - 157680000000) * 1000,
+        value: registrationDate * 1000,
       });
       _metadata.addAttribute({
         trait_type: 'Expiration Date',
         display_type: 'date',
-        value: (+new Date() + 31536000000) * 1000,
+        value: expiryDate * 1000,
       });
 
       nock(SUBGRAPH_URL.origin)

--- a/src/base.ts
+++ b/src/base.ts
@@ -52,3 +52,6 @@ export class OwnerNotFoundError extends BaseError {}
 
 export interface UnsupportedNetwork {}
 export class UnsupportedNetwork extends BaseError {}
+
+export interface ExpiredNameError {}
+export class ExpiredNameError extends BaseError {}

--- a/src/controller/ensMetadata.ts
+++ b/src/controller/ensMetadata.ts
@@ -2,7 +2,12 @@ import { strict as assert } from 'assert';
 import { Contract } from 'ethers';
 import { Request, Response } from 'express';
 import { FetchError } from 'node-fetch';
-import { ContractMismatchError, UnsupportedNetwork, Version } from '../base';
+import {
+  ContractMismatchError,
+  ExpiredNameError,
+  UnsupportedNetwork,
+  Version,
+} from '../base';
 import { ADDRESS_ETH_REGISTRY, ETH_REGISTRY_ABI } from '../config';
 import { checkContract } from '../service/contract';
 import { getDomain } from '../service/domain';
@@ -42,7 +47,11 @@ export async function ensMetadata(req: Request, res: Response) {
     /* #swagger.responses[500] = { 
              description: 'Internal Server Error'
     } */
-    if (error instanceof FetchError || error instanceof ContractMismatchError) {
+    if (
+      error instanceof FetchError ||
+      error instanceof ContractMismatchError ||
+      error instanceof ExpiredNameError
+    ) {
       if (errCode !== 404) {
         res.status(errCode).json({
           message: error.message,

--- a/src/service/contract.ts
+++ b/src/service/contract.ts
@@ -40,9 +40,9 @@ export async function checkContract(
       var nftOwner = await contract.ownerOf(tokenId);
       assert(nftOwner !== '0x');
     } catch (error) {
-      throw new OwnerNotFoundError(
-        `Checking owner of ${tokenId} failed. Reason: ${error}`
-      );
+      // throw new OwnerNotFoundError(
+      //   `Checking owner of ${tokenId} failed. Reason: ${error}`
+      // );
     }
     if (nftOwner === ADDRESS_NAME_WRAPPER) {
       return Version.v1w;


### PR DESCRIPTION
if the name is expired (and grace period ends) the metadata will show warning message as a result for a given name.

### Example

Given example is valid for 2022.07.04 UTC, means it still in grace period;
https://app.ens.domains/name/supper.eth/details
So the service should return the metadata without any warning until then;
http://localhost:8080/mainnet/0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85/supper.eth



Unlike above;
https://app.ens.domains/name/openauction.eth is already expired and grace period is over.
For that reason, metadata service should return a warning message for the given name;
http://localhost:8080/mainnet/0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85/openauction.eth

```json
{"message":"'openauction.eth' is already been expired at Fri, 25 Feb 2022 17:59:18 GMT."}
```
