### PR TITLE
add last request date field to ENS metadata response

### DIFF
--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
+    - run: sudo apt-get update
     - name: Install Pango
       run: sudo apt-get install libsdl-pango-dev libgif-dev
     - run: yarn --frozen-lockfile

--- a/src/controller/ensMetadata.ts
+++ b/src/controller/ensMetadata.ts
@@ -31,6 +31,7 @@ export async function ensMetadata(req: Request, res: Response) {
 
   const { contractAddress, networkName, tokenId: identifier } = req.params;
   const { provider, SUBGRAPH_URL } = getNetwork(networkName as NetworkName);
+  const last_request_date = Date.now();
   let tokenId, version;
   try {
     ({ tokenId, version } = await checkContract(
@@ -49,7 +50,7 @@ export async function ensMetadata(req: Request, res: Response) {
     );
 
     // add timestamp of the request date
-    result.last_request_date = Date.now();
+    result.last_request_date = last_request_date;
     /* #swagger.responses[200] = { 
       description: 'Metadata object',
       schema: { $ref: '#/definitions/ENSMetadata' }
@@ -101,7 +102,7 @@ export async function ensMetadata(req: Request, res: Response) {
         tokenId: '',
         version: Version.v1,
         // add timestamp of the request date
-        last_request_date: Date.now()
+        last_request_date
       });
       res.status(200).json({
         message: unknownMetadata,

--- a/src/controller/ensMetadata.ts
+++ b/src/controller/ensMetadata.ts
@@ -47,6 +47,9 @@ export async function ensMetadata(req: Request, res: Response) {
       version,
       false
     );
+
+    // add timestamp of the request date
+    result.last_request_date = Date.now();
     /* #swagger.responses[200] = { 
       description: 'Metadata object',
       schema: { $ref: '#/definitions/ENSMetadata' }
@@ -97,6 +100,8 @@ export async function ensMetadata(req: Request, res: Response) {
         created_date: 1580346653000,
         tokenId: '',
         version: Version.v1,
+        // add timestamp of the request date
+        last_request_date: Date.now()
       });
       res.status(200).json({
         message: unknownMetadata,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -20,6 +20,7 @@ import {
 import getNetwork from './service/network';
 import { GET_DOMAINS } from './service/subgraph';
 import { nockProvider, requireUncached } from '../mock/helper';
+import { Metadata } from './service/metadata';
 
 const TEST_NETWORK = 'goerli';
 
@@ -184,56 +185,63 @@ test('get welcome message', async (t: ExecutionContext<TestContext>) => {
 });
 
 test('get /:contractAddress/:tokenId for domain (wrappertest3.eth)', async (t: ExecutionContext<TestContext>) => {
-  const result = await got(
+  const result: Metadata = await got(
     `${METADATA_PATH}/${wrappertest3.namehash}`,
     options
   ).json();
+  delete result.last_request_date;
   t.deepEqual(result, wrappertest3.expect);
 });
 
 test('get /:contractAddress/:tokenId by decimal id', async (t: ExecutionContext<TestContext>) => {
   const intId = ethers.BigNumber.from(wrappertest3.namehash).toString();
-  const result = await got(`${METADATA_PATH}/${intId}`, options).json();
+  const result: Metadata = await got(`${METADATA_PATH}/${intId}`, options).json();
+  delete result.last_request_date;
   t.deepEqual(result, wrappertest3.expect);
 });
 
 test('get /:contractAddress/:tokenId for subdomain returns auto generated image', async (t: ExecutionContext<TestContext>) => {
-  const result = await got(
+  const result: Metadata = await got(
     `${METADATA_PATH}/${sub1Wrappertest.namehash}`,
     options
   ).json();
+  delete result.last_request_date;
   t.deepEqual(result, sub1Wrappertest.expect);
 });
 
 test('get /:contractAddress/:tokenId for subdomain returns image from text record', async (t: ExecutionContext<TestContext>) => {
-  const result = await got(
+  const result: Metadata = await got(
     `${METADATA_PATH}/${sub2Wrappertest9.namehash}`,
     options
   ).json();
+  delete result.last_request_date;
   t.deepEqual(result, sub2Wrappertest9.expect);
 });
 
 test('get /:contractAddress/:tokenId for a 21 char long domain', async (t: ExecutionContext<TestContext>) => {
-  const result = await got(
+  const result: Metadata = await got(
     `${METADATA_PATH}/${handle21character.namehash}`,
     options
   ).json();
+  delete result.last_request_date;
   t.deepEqual(result, handle21character.expect);
 });
 
 test('get /:contractAddress/:tokenId for a greater than MAX_CHAR long domain', async (t: ExecutionContext<TestContext>) => {
-  const result = await got(
+  const result: Metadata = await got(
     `${METADATA_PATH}/${supercalifragilisticexpialidocious.namehash}`,
     options
   ).json();
+  delete result.last_request_date;
   t.deepEqual(result, supercalifragilisticexpialidocious.expect);
 });
 
 test('get /:contractAddress/:tokenId for a greater than MAX_CHAR long subdomain', async (t: ExecutionContext<TestContext>) => {
-  const result = await got(
+  const result: Metadata = await got(
     `${METADATA_PATH}/${longsubdomainconsistof34charactersMdt.namehash}`,
     options
   ).json();
+  delete result.last_request_date;
   t.deepEqual(result, longsubdomainconsistof34charactersMdt.expect);
 });
 
@@ -250,10 +258,11 @@ test('get /:contractAddress/:tokenId for unknown namehash', async (t: ExecutionC
 });
 
 test('get /:contractAddress/:tokenId for unknown namehash on subgraph but registered', async (t: ExecutionContext<TestContext>) => {
-  const { message }: any = await got(
+  const { message }: { message: Metadata } = await got(
     `${METADATA_PATH}/${unknownRegistered.namehash}`,
     options
   ).json();
+  delete message.last_request_date;
   t.deepEqual(message, unknownRegistered.expect);
 });
 

--- a/src/service/metadata.ts
+++ b/src/service/metadata.ts
@@ -25,28 +25,30 @@ try {
 
 
 export interface MetadataInit {
-  name            : string;
-  description?    : string;
-  created_date    : number;
-  registered_date?: Date | null;
-  expiration_date?: Date | null;
-  tokenId         : string;
-  version         : Version;
+  name               : string;
+  description?       : string;
+  created_date       : number;
+  registered_date?   : Date | null;
+  expiration_date?   : Date | null;
+  tokenId            : string;
+  version            : Version;
+  last_request_date? : number;
 }
 
 export interface Metadata {
-  name             : string;
-  description      : string;
-  attributes       : object[];
-  name_length?     : number;
-  segment_length?  : number;
-  image            : string;
-  image_url?       : string; // same as image, keep for backward compatibility
-  is_normalized    : boolean;
-  background_image?: string;
-  mimeType?        : string;
-  url?             : string | null;
-  version          : Version;
+  name               : string;
+  description        : string;
+  attributes         : object[];
+  name_length?       : number;
+  segment_length?    : number;
+  image              : string;
+  image_url?         : string; // same as image, keep for backward compatibility
+  is_normalized      : boolean;
+  background_image?  : string;
+  mimeType?          : string;
+  url?               : string | null;
+  version            : Version;
+  last_request_date? : number;
 }
 
 export class Metadata {
@@ -57,6 +59,7 @@ export class Metadata {
     created_date,
     tokenId,
     version,
+    last_request_date
   }: MetadataInit) {
     const label = name.substring(0, name.indexOf('.'));
     const is_valid = validate(name);
@@ -109,6 +112,7 @@ https://en.wikipedia.org/wiki/IDN_homograph_attack';
       display_type: 'string',
       value: findCharacterSet(label),
     });
+    this.last_request_date = last_request_date;
   }
 
   addAttribute(attribute: object) {


### PR DESCRIPTION
`last_request_date` field will have a UTC timestamp of request being made.